### PR TITLE
fix(auth): Reset admin state on logout

### DIFF
--- a/lib/data/providers/admin_providers.dart
+++ b/lib/data/providers/admin_providers.dart
@@ -1,14 +1,24 @@
 // lib/data/providers/admin_providers.dart
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:taktik/features/auth/application/auth_controller.dart'; // Add this import
 
 final firebaseAuthProvider = Provider<FirebaseAuth>((ref) => FirebaseAuth.instance);
 
 final adminClaimProvider = FutureProvider<bool>((ref) async {
-  final user = ref.watch(firebaseAuthProvider).currentUser;
-  if (user == null) return false;
-  final token = await user.getIdTokenResult(true);
-  final claims = token.claims ?? {};
+  // Depend on the auth state stream provider
+  final user = ref.watch(authControllerProvider).value;
+
+  if (user == null) {
+    // If there is no user, they are not an admin.
+    return false;
+  }
+
+  // Force a refresh of the token to get the latest claims.
+  final tokenResult = await user.getIdTokenResult(true);
+  final claims = tokenResult.claims ?? {};
+
+  // Return true if the 'admin' claim is set to true.
   return claims['admin'] == true;
 });
 


### PR DESCRIPTION
The `adminClaimProvider` was not re-evaluating when the user logged out and a new user logged in. This was because it depended on `FirebaseAuth.instance.currentUser`, which did not trigger a rebuild in the Riverpod provider.

This change modifies `adminClaimProvider` to depend on the `authControllerProvider` stream. This ensures the provider is invalidated and re-runs whenever the authentication state changes, correctly clearing the admin status for non-admin users.